### PR TITLE
Add Flutter OCR skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+build/
+
+# IntelliJ related
+*.iml
+.idea/
+
+# VS Code related
+.vscode/
+
+# Others
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# scanQ
+# ScanQ
+
+ScanQ is a Flutter application for scanning CSAT-style questions using OCR.
+
+## Development
+
+This project uses the following folders:
+
+- `lib/scanning` – camera and OCR logic
+- `lib/parsing` – parsing scanned text into question components
+- `lib/saving` – saving extracted questions
+- `lib/review` – reviewing saved questions
+
+Run `flutter pub get` to install dependencies.
+
+Use `flutter run` to launch the app on an Android device or emulator.

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'scanning/scanner_page.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('ScanQ')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const ScannerPage()),
+            );
+          },
+          child: const Text('Start Scanning'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'home_page.dart';
+
+void main() {
+  runApp(const ScanQApp());
+}
+
+class ScanQApp extends StatelessWidget {
+  const ScanQApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'ScanQ',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const HomePage(),
+    );
+  }
+}

--- a/lib/models/csat_question.dart
+++ b/lib/models/csat_question.dart
@@ -1,0 +1,8 @@
+class CSATQuestion {
+  final int? number;
+  final String body;
+  final List<String> choices;
+  final List<String> imagePaths;
+
+  CSATQuestion({this.number, required this.body, this.choices = const [], this.imagePaths = const []});
+}

--- a/lib/parsing/csat_parser.dart
+++ b/lib/parsing/csat_parser.dart
@@ -1,0 +1,18 @@
+import '../models/csat_question.dart';
+
+class CSATParser {
+  CSATQuestion parse(String text) {
+    // TODO: implement more sophisticated parsing of CSAT-style problems.
+    final lines = text.split('\n');
+    int? number;
+    if (lines.isNotEmpty) {
+      final first = lines.first.trim();
+      final numMatch = RegExp(r'^(\d+)').firstMatch(first);
+      if (numMatch != null) {
+        number = int.tryParse(numMatch.group(1)!);
+      }
+    }
+    final body = lines.join('\n');
+    return CSATQuestion(number: number, body: body);
+  }
+}

--- a/lib/review/review_page.dart
+++ b/lib/review/review_page.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class ReviewPage extends StatelessWidget {
+  const ReviewPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Review Questions')),
+      body: const Center(child: Text('Review saved questions here.')),
+    );
+  }
+}

--- a/lib/saving/storage_service.dart
+++ b/lib/saving/storage_service.dart
@@ -1,0 +1,11 @@
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
+import '../models/csat_question.dart';
+
+class StorageService {
+  Future<File> saveQuestion(CSATQuestion question) async {
+    final dir = await getApplicationDocumentsDirectory();
+    final file = File('${dir.path}/question_${question.number ?? DateTime.now().millisecondsSinceEpoch}.txt');
+    return file.writeAsString(question.body);
+  }
+}

--- a/lib/scanning/scanner_page.dart
+++ b/lib/scanning/scanner_page.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:camera/camera.dart';
+import 'package:flutter/material.dart';
+import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+
+import '../parsing/csat_parser.dart';
+import '../models/csat_question.dart';
+
+class ScannerPage extends StatefulWidget {
+  const ScannerPage({Key? key}) : super(key: key);
+
+  @override
+  State<ScannerPage> createState() => _ScannerPageState();
+}
+
+class _ScannerPageState extends State<ScannerPage> {
+  CameraController? _controller;
+  late Future<void> _initializeControllerFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeCamera();
+  }
+
+  Future<void> _initializeCamera() async {
+    final cameras = await availableCameras();
+    final camera = cameras.first;
+    _controller = CameraController(camera, ResolutionPreset.medium);
+    _initializeControllerFuture = _controller!.initialize();
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  Future<void> _scan() async {
+    if (_controller == null) return;
+    await _initializeControllerFuture;
+    final picture = await _controller!.takePicture();
+    final file = File(picture.path);
+    final inputImage = InputImage.fromFile(file);
+    final textRecognizer = TextRecognizer(script: TextRecognitionScript.korean);
+    final recognizedText = await textRecognizer.processImage(inputImage);
+    await textRecognizer.close();
+
+    final parser = CSATParser();
+    final CSATQuestion question = parser.parse(recognizedText.text);
+
+    if (!mounted) return;
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Recognized Question'),
+        content: SingleChildScrollView(child: Text(question.body)),
+        actions: [TextButton(onPressed: () => Navigator.pop(context), child: const Text('OK'))],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Scan Question')),
+      body: _controller == null
+          ? const Center(child: CircularProgressIndicator())
+          : Stack(
+              children: [
+                CameraPreview(_controller!),
+                Positioned(
+                  bottom: 16,
+                  left: 0,
+                  right: 0,
+                  child: Center(
+                    child: FloatingActionButton(
+                      onPressed: _scan,
+                      child: const Icon(Icons.camera_alt),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,17 @@
+name: scanq
+description: OCR app for Korean CSAT questions
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  camera: ^0.10.0+4
+  google_mlkit_text_recognition: ^0.5.0
+  path_provider: ^2.0.11
+
+flutter:
+  uses-material-design: true

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('sample test', () {
+    expect(1 + 1, equals(2));
+  });
+}


### PR DESCRIPTION
## Summary
- add initial Flutter project for ScanQ
- implement home screen with scanning button
- add scanner page using camera and OCR
- define CSAT question model and basic parser
- document project structure

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1f340f948322a65238eec68380cb