### PR TITLE
Add focus and preprocessing improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+build/
+
+# IntelliJ related
+*.iml
+.idea/
+
+# VS Code related
+.vscode/
+
+# Others
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,65 @@
-# scanQ
+# ScanQ
+
+ScanQ is a Flutter application for scanning CSAT-style questions using OCR.
+
+## Development
+
+This project uses the following folders:
+
+- `lib/scanning` – camera and OCR logic
+- `lib/parsing` – parsing scanned text into question components, including
+  formula extraction
+- `lib/saving` – saving extracted questions
+- `lib/review` – reviewing saved questions
+
+Run `flutter pub get` to install dependencies.
+
+Use `flutter run` to launch the app on an Android device or emulator.
+
+On the scanner screen tap the floating camera button to capture a photo. After
+processing, the captured image is shown with green boxes around each detected
+text block so you can verify what was recognized. While
+the camera preview is running the app continuously performs lightweight OCR and
+draws a red bounding box over the scan area when text is detected. Only the
+scanning region is processed for the final capture which can help prevent
+crashes on low-memory devices. The parsed result now includes any mathematical
+formulas found in the text so you can verify them separately.
+
+### Improving OCR quality
+
+ScanQ captures photos using the highest available camera resolution and
+preprocesses them before OCR. You can tap the preview to manually adjust the
+focus point, which is shown with a yellow circle. Photos are enhanced before
+recognition:
+
+- The captured image orientation is fixed to avoid rotated text.
+- Only the region inside the scan box is cropped for processing.
+- The cropped image is blurred slightly to remove noise then converted to
+  grayscale.
+- Contrast is increased and the image is binarized so text appears clearly.
+- The processed image with detected text blocks is shown after each scan so you
+  can verify the OCR result visually.
+
+These steps help Google MLKit produce more accurate recognition results.
+
+Additionally the camera image stream now provides the row stride
+(bytesPerRow) of the image so MLKit can correctly interpret YUV frames.
+This helps reduce recognition errors on some devices.
+
+Math formulas detected in the recognized text are extracted and stored with
+each question so they can be handled separately in the future.
+The formula extractor now recognizes fractions like `1/2` or `a ÷ b` so
+expressions with division are parsed correctly.
+
+The Android build requires camera permissions. Ensure that your
+`android/app/src/main/AndroidManifest.xml` includes:
+
+```xml
+<uses-permission android:name="android.permission.CAMERA" />
+```
+
+On modern Android versions the app also requests camera access at runtime using
+the `permission_handler` plugin. Make sure you grant the permission when
+prompted, otherwise the scanner screen will show an error.
+
+If the platform folders are missing, run `flutter create .` to generate them.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.scanq">
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.CAMERA"/>
+
+    <application
+        android:label="scanq"
+        android:name="${applicationName}"
+        android:icon="@mipmap/ic_launcher">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:theme="@style/LaunchTheme"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:hardwareAccelerated="true"
+            android:windowSoftInputMode="adjustResize">
+            <meta-data
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme" />
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'scanning/scanner_page.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('ScanQ')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const ScannerPage()),
+            );
+          },
+          child: const Text('Start Scanning'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'home_page.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const ScanQApp());
+}
+
+class ScanQApp extends StatelessWidget {
+  const ScanQApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'ScanQ',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const HomePage(),
+    );
+  }
+}

--- a/lib/models/csat_question.dart
+++ b/lib/models/csat_question.dart
@@ -1,0 +1,15 @@
+class CSATQuestion {
+  final int? number;
+  final String body;
+  final List<String> choices;
+  final List<String> imagePaths;
+  final List<String> formulas;
+
+  CSATQuestion({
+    this.number,
+    required this.body,
+    this.choices = const [],
+    this.imagePaths = const [],
+    this.formulas = const [],
+  });
+}

--- a/lib/parsing/csat_parser.dart
+++ b/lib/parsing/csat_parser.dart
@@ -1,0 +1,21 @@
+import '../models/csat_question.dart';
+import 'math_parser.dart';
+
+class CSATParser {
+  CSATQuestion parse(String text) {
+    // TODO: implement more sophisticated parsing of CSAT-style problems.
+    final lines = text.split('\n');
+    int? number;
+    if (lines.isNotEmpty) {
+      final first = lines.first.trim();
+      final numMatch = RegExp(r'^(\d+)').firstMatch(first);
+      if (numMatch != null) {
+        number = int.tryParse(numMatch.group(1)!);
+      }
+    }
+    final body = lines.join('\n');
+    final mathParser = MathParser();
+    final formulas = mathParser.extractFormulas(text);
+    return CSATQuestion(number: number, body: body, formulas: formulas);
+  }
+}

--- a/lib/parsing/math_parser.dart
+++ b/lib/parsing/math_parser.dart
@@ -1,0 +1,24 @@
+class MathParser {
+  /// Extracts potential formulas from the given [text].
+  ///
+  /// A formula is considered any line containing digits and a mathematical
+  /// operator such as +, -, ×, x, *, /, ^, =, <, or >. Fractions using `/`
+  /// or `÷` are also detected. Parentheses may surround variables or digits.
+  List<String> extractFormulas(String text) {
+    final List<String> formulas = [];
+    final lines = text.split('\n');
+    final regex = RegExp(
+      r'[\w\d()]+(?:\s*[+\-x×*÷/=^<>]\s*[\w\d()]+)+',
+    );
+    for (final line in lines) {
+      final matches = regex.allMatches(line);
+      for (final match in matches) {
+        final formula = match.group(0);
+        if (formula != null && formula.trim().isNotEmpty) {
+          formulas.add(formula.trim());
+        }
+      }
+    }
+    return formulas;
+  }
+}

--- a/lib/review/review_page.dart
+++ b/lib/review/review_page.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class ReviewPage extends StatelessWidget {
+  const ReviewPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Review Questions')),
+      body: const Center(child: Text('Review saved questions here.')),
+    );
+  }
+}

--- a/lib/saving/storage_service.dart
+++ b/lib/saving/storage_service.dart
@@ -1,0 +1,11 @@
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
+import '../models/csat_question.dart';
+
+class StorageService {
+  Future<File> saveQuestion(CSATQuestion question) async {
+    final dir = await getApplicationDocumentsDirectory();
+    final file = File('${dir.path}/question_${question.number ?? DateTime.now().millisecondsSinceEpoch}.txt');
+    return file.writeAsString(question.body);
+  }
+}

--- a/lib/scanning/scanner_page.dart
+++ b/lib/scanning/scanner_page.dart
@@ -1,0 +1,500 @@
+import 'dart:io';
+import 'dart:math' as math;
+import 'package:image/image.dart' as img;
+
+import 'package:camera/camera.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
+import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+import 'package:google_mlkit_commons/google_mlkit_commons.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import '../parsing/csat_parser.dart';
+import '../models/csat_question.dart';
+
+class ScannerPage extends StatefulWidget {
+  const ScannerPage({Key? key}) : super(key: key);
+
+  @override
+  State<ScannerPage> createState() => _ScannerPageState();
+}
+
+class _ScannerPageState extends State<ScannerPage> {
+  CameraController? _controller;
+  Future<void>? _initializeControllerFuture;
+  bool _isScanning = false;
+  Rect? _detectedRect; // normalized rect within the scan area
+  Offset? _lastTap;
+
+  bool _processingImage = false;
+  DateTime _lastDetection = DateTime.fromMillisecondsSinceEpoch(0);
+  static const _detectionInterval = Duration(milliseconds: 700);
+
+  img.Image _binarize(img.Image src, {int threshold = 150}) {
+    final out = img.Image.from(src);
+    for (int y = 0; y < out.height; y++) {
+      for (int x = 0; x < out.width; x++) {
+        final c = out.getPixel(x, y);
+        final l = img.getRed(c); // grayscale so R=G=B
+        final v = l > threshold ? 255 : 0;
+        out.setPixelRgba(x, y, v, v, v);
+      }
+    }
+    return out;
+  }
+
+  late final TextRecognizer _textRecognizer;
+
+  // Relative scan area (percent of preview) shown with a bounding box.
+  static const Rect _relativeScanRect =
+      Rect.fromLTWH(0.1, 0.25, 0.8, 0.5); // left, top, width, height
+
+  Rect _calculateScanRect(Size size) {
+    return Rect.fromLTWH(
+      size.width * _relativeScanRect.left,
+      size.height * _relativeScanRect.top,
+      size.width * _relativeScanRect.width,
+      size.height * _relativeScanRect.height,
+    );
+  }
+
+  Rect _imageCropRect(int width, int height) {
+    return Rect.fromLTWH(
+      width * _relativeScanRect.left,
+      height * _relativeScanRect.top,
+      width * _relativeScanRect.width,
+      height * _relativeScanRect.height,
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _textRecognizer = TextRecognizer(script: TextRecognitionScript.korean);
+    _initializeCamera();
+  }
+
+  Future<void> _initializeCamera() async {
+    final status = await Permission.camera.request();
+    if (!status.isGranted) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Camera permission denied')),
+        );
+      }
+      return;
+    }
+    try {
+      final cameras = await availableCameras();
+      if (cameras.isEmpty) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('No camera found')),
+          );
+        }
+        return;
+      }
+      final camera = cameras.first;
+      // Use the highest available resolution to improve OCR accuracy.
+      final controller = CameraController(
+        camera,
+        ResolutionPreset.max,
+        enableAudio: false,
+        imageFormatGroup: ImageFormatGroup.yuv420,
+      );
+      _controller = controller;
+      _initializeControllerFuture = controller.initialize();
+      await _initializeControllerFuture;
+      await controller.startImageStream(_processCameraImage);
+      if (mounted) {
+        setState(() {});
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to initialize camera: $e')),
+        );
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller?.stopImageStream();
+    _controller?.dispose();
+    _textRecognizer.close();
+    super.dispose();
+  }
+
+  void _onViewFinderTap(
+      TapDownDetails details, BoxConstraints constraints) {
+    final offset = Offset(
+      details.localPosition.dx / constraints.maxWidth,
+      details.localPosition.dy / constraints.maxHeight,
+    );
+    _lastTap = offset;
+    _controller?.setFocusPoint(offset);
+    _controller?.setExposurePoint(offset);
+    _controller?.setFocusMode(FocusMode.auto);
+  }
+
+  Future<void> _processCameraImage(CameraImage image) async {
+    if (_processingImage) return;
+    final now = DateTime.now();
+    if (now.difference(_lastDetection) < _detectionInterval) return;
+    _processingImage = true;
+    _lastDetection = now;
+    try {
+      final WriteBuffer allBytes = WriteBuffer();
+      for (final plane in image.planes) {
+        allBytes.putUint8List(plane.bytes);
+      }
+      final bytes = allBytes.done().buffer.asUint8List();
+
+      final metadata = InputImageMetadata(
+        size: Size(image.width.toDouble(), image.height.toDouble()),
+        rotation: InputImageRotationValue.fromRawValue(
+                _controller!.description.sensorOrientation) ??
+            InputImageRotation.rotation0deg,
+        format:
+            InputImageFormatValue.fromRawValue(image.format.raw) ??
+                InputImageFormat.nv21,
+        bytesPerRow: image.planes.first.bytesPerRow,
+      );
+
+      final inputImage =
+          InputImage.fromBytes(bytes: bytes, metadata: metadata);
+      final recognizedText = await _textRecognizer.processImage(inputImage);
+
+      Rect? detected;
+      if (recognizedText.blocks.isNotEmpty) {
+        double minX = double.infinity;
+        double minY = double.infinity;
+        double maxX = 0;
+        double maxY = 0;
+        for (final block in recognizedText.blocks) {
+          final box = block.boundingBox;
+          if (box != null) {
+            minX = math.min(minX, box.left.toDouble());
+            minY = math.min(minY, box.top.toDouble());
+            maxX = math.max(maxX, box.right.toDouble());
+            maxY = math.max(maxY, box.bottom.toDouble());
+          }
+        }
+        if (maxX > minX && maxY > minY) {
+          final w = image.width.toDouble();
+          final h = image.height.toDouble();
+          final rectNorm = Rect.fromLTRB(
+            minX / w,
+            minY / h,
+            maxX / w,
+            maxY / h,
+          );
+          final inter = rectNorm.intersect(_relativeScanRect);
+          if (!inter.isEmpty) {
+            detected = Rect.fromLTRB(
+              (inter.left - _relativeScanRect.left) / _relativeScanRect.width,
+              (inter.top - _relativeScanRect.top) / _relativeScanRect.height,
+              (inter.right - _relativeScanRect.left) / _relativeScanRect.width,
+              (inter.bottom - _relativeScanRect.top) / _relativeScanRect.height,
+            );
+          }
+        }
+      }
+
+      if (mounted) {
+        setState(() {
+          _detectedRect = detected;
+        });
+      }
+    } catch (_) {
+      // ignore stream errors
+    } finally {
+      _processingImage = false;
+    }
+  }
+
+  Future<void> _scan() async {
+    if (_isScanning || _controller == null || _initializeControllerFuture == null) return;
+    setState(() {
+      _isScanning = true;
+      _detectedRect = null;
+    });
+    try {
+      await _initializeControllerFuture;
+      await _controller!.stopImageStream();
+      final picture = await _controller!.takePicture();
+      final file = File(picture.path);
+      final bytes = await file.readAsBytes();
+      final img.Image? original = img.decodeImage(bytes);
+      late final InputImage inputImage;
+      Rect? crop;
+      String? croppedPath;
+      if (original != null) {
+        // Correct the orientation and enhance the image for better recognition.
+        img.Image processed = img.bakeOrientation(original);
+        crop = _imageCropRect(processed.width, processed.height);
+        processed = img.copyCrop(
+          processed,
+          x: crop.left.toInt(),
+          y: crop.top.toInt(),
+          width: crop.width.toInt(),
+          height: crop.height.toInt(),
+        );
+        processed = img.gaussianBlur(processed, 1);
+        processed = img.grayscale(processed);
+        processed = img.adjustColor(processed, contrast: 1.5);
+        processed = _binarize(processed);
+        croppedPath = '${file.path}_crop.jpg';
+        await File(croppedPath).writeAsBytes(img.encodeJpg(processed));
+        inputImage = InputImage.fromFilePath(croppedPath);
+      } else {
+        inputImage = InputImage.fromFile(file);
+      }
+      final textRecognizer =
+          TextRecognizer(script: TextRecognitionScript.korean);
+      final recognizedText = await textRecognizer.processImage(inputImage);
+      await textRecognizer.close();
+
+      Rect? detected;
+      if (recognizedText.blocks.isNotEmpty) {
+        double minX = double.infinity;
+        double minY = double.infinity;
+        double maxX = 0;
+        double maxY = 0;
+        for (final block in recognizedText.blocks) {
+          final box = block.boundingBox;
+          if (box != null) {
+            minX = math.min(minX, box.left.toDouble());
+            minY = math.min(minY, box.top.toDouble());
+            maxX = math.max(maxX, box.right.toDouble());
+            maxY = math.max(maxY, box.bottom.toDouble());
+          }
+        }
+        if (maxX > minX && maxY > minY) {
+          final w = crop?.width ?? original?.width ?? 1;
+          final h = crop?.height ?? original?.height ?? 1;
+          detected = Rect.fromLTRB(
+            minX / w,
+            minY / h,
+            maxX / w,
+            maxY / h,
+          );
+        }
+      }
+
+      final parser = CSATParser();
+      final CSATQuestion question = parser.parse(recognizedText.text);
+      setState(() {
+        _detectedRect = detected;
+      });
+      if (!mounted) return;
+      await _showResult(croppedPath ?? file.path,
+          Size((crop?.width ?? original?.width ?? 1).toDouble(),
+              (crop?.height ?? original?.height ?? 1).toDouble()),
+          recognizedText,
+          question);
+      await _controller!.startImageStream(_processCameraImage);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Failed to scan: $e')));
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isScanning = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _showResult(String imagePath, Size imageSize,
+      RecognizedText recognizedText, CSATQuestion question) async {
+    await showDialog(
+      context: context,
+      builder: (_) {
+        return Dialog(
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                AspectRatio(
+                  aspectRatio: imageSize.width / imageSize.height,
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      Image.file(File(imagePath), fit: BoxFit.contain),
+                      Positioned.fill(
+                        child: CustomPaint(
+                          painter:
+                              _BlocksPainter(recognizedText.blocks, imageSize),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text(question.body),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Close'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Scan Question')),
+      body: _controller == null
+          ? const Center(child: CircularProgressIndicator())
+          : FutureBuilder<void>(
+              future: _initializeControllerFuture,
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.done) {
+                  return Stack(
+                    children: [
+                      LayoutBuilder(
+                        builder: (context, constraints) {
+                          return GestureDetector(
+                            behavior: HitTestBehavior.opaque,
+                            onTapDown: (details) =>
+                                _onViewFinderTap(details, constraints),
+                            child: CameraPreview(_controller!),
+                          );
+                        },
+                      ),
+                      if (_lastTap != null)
+                        Positioned.fill(
+                          child: IgnorePointer(
+                            child: CustomPaint(
+                              painter: _FocusPointPainter(_lastTap!),
+                            ),
+                          ),
+                        ),
+                      if (_detectedRect != null)
+                        Positioned.fill(
+                          child: IgnorePointer(
+                            child: CustomPaint(
+                              painter: _BoundingBoxPainter(
+                                _detectedRect!,
+                                MediaQuery.of(context).size,
+                                _calculateScanRect(MediaQuery.of(context).size),
+                              ),
+                            ),
+                          ),
+                        ),
+                      if (_isScanning)
+                        Container(
+                          color: Colors.black45,
+                          child: const Center(child: CircularProgressIndicator()),
+                        ),
+                      Positioned(
+                        bottom: 16,
+                        left: 0,
+                        right: 0,
+                        child: Center(
+                          child: FloatingActionButton(
+                            onPressed: _scan,
+                            child: const Icon(Icons.camera_alt),
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                } else {
+                  return const Center(child: CircularProgressIndicator());
+                }
+              },
+            ),
+    );
+  }
+}
+
+class _BlocksPainter extends CustomPainter {
+  final List<TextBlock> blocks;
+  final Size imageSize;
+
+  _BlocksPainter(this.blocks, this.imageSize);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.greenAccent
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2;
+    for (final block in blocks) {
+      final box = block.boundingBox;
+      if (box != null) {
+        final rect = Rect.fromLTRB(
+          box.left / imageSize.width * size.width,
+          box.top / imageSize.height * size.height,
+          box.right / imageSize.width * size.width,
+          box.bottom / imageSize.height * size.height,
+        );
+        canvas.drawRect(rect, paint);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _BlocksPainter oldDelegate) {
+    return oldDelegate.blocks != blocks;
+  }
+}
+
+class _BoundingBoxPainter extends CustomPainter {
+  final Rect rect;
+  final Size screenSize;
+  final Rect scanRect;
+
+  _BoundingBoxPainter(this.rect, this.screenSize, this.scanRect);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.redAccent
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 3;
+    final converted = Rect.fromLTRB(
+      scanRect.left + rect.left * scanRect.width,
+      scanRect.top + rect.top * scanRect.height,
+      scanRect.left + rect.right * scanRect.width,
+      scanRect.top + rect.bottom * scanRect.height,
+    );
+    canvas.drawRect(converted, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _BoundingBoxPainter oldDelegate) {
+    return oldDelegate.rect != rect;
+  }
+}
+
+class _FocusPointPainter extends CustomPainter {
+  final Offset offset;
+  _FocusPointPainter(this.offset);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final point = Offset(offset.dx * size.width, offset.dy * size.height);
+    final paint = Paint()
+      ..color = Colors.yellowAccent
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2;
+    const radius = 20.0;
+    canvas.drawCircle(point, radius, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _FocusPointPainter oldDelegate) {
+    return oldDelegate.offset != offset;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,19 @@
+name: scanq
+description: OCR app for Korean CSAT questions
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  camera: ^0.10.0+4
+  google_mlkit_text_recognition: ^0.8.0
+  path_provider: ^2.0.11
+  permission_handler: ^10.2.0
+  image: ^4.0.17
+
+flutter:
+  uses-material-design: true

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scanq/parsing/math_parser.dart';
+
+void main() {
+  test('sample test', () {
+    expect(1 + 1, equals(2));
+  });
+
+  test('math parser extracts formulas', () {
+    const text = '1 + 2 = 3\n다음 중 x^2 + 3x + 2 = 0 의 해를 고르시오';
+    final parser = MathParser();
+    final formulas = parser.extractFormulas(text);
+    expect(formulas, contains('1 + 2 = 3'));
+    expect(formulas.any((f) => f.contains('x^2')), isTrue);
+  });
+
+  test('math parser detects fractions', () {
+    const text = '분수 예: 3/4 + 1/2 = 5/4';
+    final parser = MathParser();
+    final formulas = parser.extractFormulas(text);
+    expect(formulas.any((f) => f.contains('3/4 + 1/2')), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- preprocess captured image with blur and binarization
- allow manual tap-to-focus and show focus point
- show processed scan result with bounding boxes
- document focus and enhanced preprocessing steps

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1f340f948322a65238eec68380cb